### PR TITLE
feat: human-readable timestamp and date formatting

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -481,7 +481,7 @@ class TestTimestampFormatting:
     def test_format_ts_preserves_time(self):
         iso = "2026-03-24T15:30:00+00:00"
         result = _format_ts(iso, "12h")
-        assert "AM" in result or "PM" in result
+        assert re.search(r"\b(AM|PM)\b", result)
 
     def test_start_text_output_is_formatted(self, tmp_db):
         result = runner.invoke(app, ["start"])
@@ -538,24 +538,22 @@ class TestTimestampFormatting:
     def test_format_ts_12h_contains_am_pm(self):
         iso = "2026-03-24T15:30:00+00:00"
         result = _format_ts(iso, "12h")
-        assert "AM" in result or "PM" in result
+        assert re.search(r"\b(AM|PM)\b", result)
 
     def test_format_ts_24h_no_am_pm(self):
         iso = "2026-03-24T15:30:00+00:00"
         result = _format_ts(iso, "24h")
-        assert "AM" not in result
-        assert "PM" not in result
+        assert not re.search(r"\b(AM|PM)\b", result)
 
     def test_start_respects_24h_format(self, tmp_db, monkeypatch):
         monkeypatch.setenv("TIME_FORMAT", "24h")
         result = runner.invoke(app, ["start"])
         assert result.exit_code == 0
-        assert "AM" not in result.stdout
-        assert "PM" not in result.stdout
+        assert not re.search(r"\b(AM|PM)\b", result.stdout)
         assert not self._ISO_PATTERN.search(result.stdout)
 
     def test_start_respects_12h_format(self, tmp_db, monkeypatch):
         monkeypatch.setenv("TIME_FORMAT", "12h")
         result = runner.invoke(app, ["start"])
         assert result.exit_code == 0
-        assert "AM" in result.stdout or "PM" in result.stdout
+        assert re.search(r"\b(AM|PM)\b", result.stdout)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,6 +263,7 @@ class TestSetup:
             "~/invoices",
             "Please pay within 30 days.",
             "0",
+            "12h",  # time format
         ])
         result = runner.invoke(app, ["setup"], input=inputs + "\n")
         assert result.exit_code == 0
@@ -296,16 +297,17 @@ class TestSetup:
 
         # Accept all defaults by pressing Enter, except hourly rate
         inputs = "\n".join([
-            "y",   # confirm edit
-            "",    # contractor name (keep "Jane Smith")
-            "",    # contractor address
-            "",    # contractor email
-            "",    # client name (keep "Acme")
-            "",    # client address
-            "200", # update hourly rate
-            "",    # invoice output dir
-            "",    # payment instructions
-            "",    # invoice number offset
+            "y",    # confirm edit
+            "",     # contractor name (keep "Jane Smith")
+            "",     # contractor address
+            "",     # contractor email
+            "",     # client name (keep "Acme")
+            "",     # client address
+            "200",  # update hourly rate
+            "",     # invoice output dir
+            "",     # payment instructions
+            "",     # invoice number offset
+            "",     # time format (keep default)
         ])
         result = runner.invoke(app, ["setup"], input=inputs + "\n")
         assert result.exit_code == 0
@@ -322,6 +324,7 @@ class TestSetup:
             "", "", "", "", "", "150", "~/invoices", "Pay.",
             "-1",  # rejected
             "5",   # accepted
+            "",    # time format (keep default)
         ])
         result = runner.invoke(app, ["setup"], input=inputs + "\n")
         assert result.exit_code == 0
@@ -336,7 +339,7 @@ class TestSetup:
 
         inputs = "\n".join([
             "y",   # confirm edit
-            "", "", "", "", "", "150", "~/invoices", "Pay.", "",
+            "", "", "", "", "", "150", "~/invoices", "Pay.", "", "",
         ])
         result = runner.invoke(app, ["setup"], input=inputs + "\n")
         assert result.exit_code == 0
@@ -348,12 +351,51 @@ class TestSetup:
 
         inputs = "\n".join([
             'O\'Brien & "Co"',  # name with embedded double quotes
-            "", "", "", "", "100", "~/invoices", "Pay.", "0",
+            "", "", "", "", "100", "~/invoices", "Pay.", "0", "",
         ])
         result = runner.invoke(app, ["setup"], input=inputs + "\n")
         assert result.exit_code == 0
         content = config_path.read_text()
         assert '\\"' in content  # double quotes are escaped
+
+    def test_setup_writes_time_format(self, tmp_path, monkeypatch):
+        config_path = tmp_path / ".env"
+        monkeypatch.setenv("TIMECARD_CONFIG_PATH", str(config_path))
+
+        inputs = "\n".join([
+            "", "", "", "", "", "150", "~/invoices", "Pay.", "0", "", "24h",
+        ])
+        result = runner.invoke(app, ["setup"], input=inputs + "\n")
+        assert result.exit_code == 0
+        assert "TIME_FORMAT=24h" in config_path.read_text()
+
+    def test_setup_rejects_invalid_time_format(self, tmp_path, monkeypatch):
+        config_path = tmp_path / ".env"
+        monkeypatch.setenv("TIMECARD_CONFIG_PATH", str(config_path))
+
+        inputs = "\n".join([
+            "", "", "", "", "", "150", "~/invoices", "Pay.", "0",
+            "bad",  # rejected
+            "12h",  # accepted
+        ])
+        result = runner.invoke(app, ["setup"], input=inputs + "\n")
+        assert result.exit_code == 0
+        assert "TIME_FORMAT=12h" in config_path.read_text()
+        assert "must be '12h' or '24h'" in result.stdout
+
+    def test_setup_preserves_existing_time_format(self, tmp_path, monkeypatch):
+        config_path = tmp_path / ".env"
+        config_path.write_text("TIME_FORMAT=24h\nHOURLY_RATE=100\n")
+        monkeypatch.setenv("TIMECARD_CONFIG_PATH", str(config_path))
+
+        # Accept all defaults — time format should default to "24h" from file
+        inputs = "\n".join([
+            "y",   # confirm edit
+            "", "", "", "", "", "", "", "", "", "", "",
+        ])
+        result = runner.invoke(app, ["setup"], input=inputs + "\n")
+        assert result.exit_code == 0
+        assert "TIME_FORMAT=24h" in config_path.read_text()
 
 
 class TestUpdate:
@@ -438,7 +480,7 @@ class TestTimestampFormatting:
 
     def test_format_ts_preserves_time(self):
         iso = "2026-03-24T15:30:00+00:00"
-        result = _format_ts(iso)
+        result = _format_ts(iso, "12h")
         assert "AM" in result or "PM" in result
 
     def test_start_text_output_is_formatted(self, tmp_db):
@@ -492,3 +534,28 @@ class TestTimestampFormatting:
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert self._ISO_PATTERN.search(data["started_at"])
+
+    def test_format_ts_12h_contains_am_pm(self):
+        iso = "2026-03-24T15:30:00+00:00"
+        result = _format_ts(iso, "12h")
+        assert "AM" in result or "PM" in result
+
+    def test_format_ts_24h_no_am_pm(self):
+        iso = "2026-03-24T15:30:00+00:00"
+        result = _format_ts(iso, "24h")
+        assert "AM" not in result
+        assert "PM" not in result
+
+    def test_start_respects_24h_format(self, tmp_db, monkeypatch):
+        monkeypatch.setenv("TIME_FORMAT", "24h")
+        result = runner.invoke(app, ["start"])
+        assert result.exit_code == 0
+        assert "AM" not in result.stdout
+        assert "PM" not in result.stdout
+        assert not self._ISO_PATTERN.search(result.stdout)
+
+    def test_start_respects_12h_format(self, tmp_db, monkeypatch):
+        monkeypatch.setenv("TIME_FORMAT", "12h")
+        result = runner.invoke(app, ["start"])
+        assert result.exit_code == 0
+        assert "AM" in result.stdout or "PM" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,14 @@
 """Tests for timecard.cli — Typer CLI commands via CliRunner."""
 
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
-from timecard.cli import app
+from timecard.cli import _format_ts, app
 from timecard.config import Settings
 from timecard.db import add_entry, get_connection, get_entry
 from timecard.models import Entry
@@ -421,3 +422,73 @@ class TestUpdate:
         data = json.loads(result.stdout)
         assert "error" in data
         assert "uv not found" in data["error"]
+
+
+class TestTimestampFormatting:
+    """Tests for human-readable timestamp formatting in CLI text output."""
+
+    _ISO_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+    def test_format_ts_returns_readable_string(self):
+        iso = "2026-03-24T15:30:00+00:00"
+        result = _format_ts(iso)
+        assert not self._ISO_PATTERN.search(result)
+        assert "Mar" in result
+        assert "2026" in result
+
+    def test_format_ts_preserves_time(self):
+        iso = "2026-03-24T15:30:00+00:00"
+        result = _format_ts(iso)
+        assert "AM" in result or "PM" in result
+
+    def test_start_text_output_is_formatted(self, tmp_db):
+        result = runner.invoke(app, ["start"])
+        assert result.exit_code == 0
+        assert not self._ISO_PATTERN.search(result.stdout)
+
+    def test_start_json_output_preserves_iso(self, tmp_db):
+        result = runner.invoke(app, ["start", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert self._ISO_PATTERN.search(data["started_at"])
+
+    def test_pause_text_output_is_formatted(self, tmp_db):
+        runner.invoke(app, ["start"])
+        result = runner.invoke(app, ["pause"])
+        assert result.exit_code == 0
+        assert not self._ISO_PATTERN.search(result.stdout)
+
+    def test_pause_json_output_preserves_iso(self, tmp_db):
+        runner.invoke(app, ["start"])
+        result = runner.invoke(app, ["pause", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert self._ISO_PATTERN.search(data["paused_at"])
+
+    def test_resume_text_output_is_formatted(self, tmp_db):
+        runner.invoke(app, ["start"])
+        runner.invoke(app, ["pause"])
+        result = runner.invoke(app, ["resume"])
+        assert result.exit_code == 0
+        assert not self._ISO_PATTERN.search(result.stdout)
+
+    def test_resume_json_output_preserves_iso(self, tmp_db):
+        runner.invoke(app, ["start"])
+        runner.invoke(app, ["pause"])
+        result = runner.invoke(app, ["resume", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert self._ISO_PATTERN.search(data["resumed_at"])
+
+    def test_status_text_output_is_formatted(self, tmp_db):
+        runner.invoke(app, ["start"])
+        result = runner.invoke(app, ["status"])
+        assert result.exit_code == 0
+        assert not self._ISO_PATTERN.search(result.stdout)
+
+    def test_status_json_output_preserves_iso(self, tmp_db):
+        runner.invoke(app, ["start"])
+        result = runner.invoke(app, ["status", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert self._ISO_PATTERN.search(data["started_at"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ class TestSettings:
         s = Settings()
         assert s.hourly_rate == 150.0
         assert s.contractor_name == ""
+        assert s.time_format == "24h"
 
     def test_get_db_path(self, tmp_path):
         s = Settings(db_path=str(tmp_path / "data" / "test.db"))
@@ -72,6 +73,27 @@ class TestLoadSettings:
         settings = load_settings(str(env_file))
         assert settings.contractor_name == ""
         monkeypatch.delenv("CONTRACTOR_NAME", raising=False)
+
+    def test_time_format_loaded_from_file(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("TIME_FORMAT=24h\n")
+        os.environ.pop("TIME_FORMAT", None)
+        settings = load_settings(str(env_file))
+        assert settings.time_format == "24h"
+
+    def test_time_format_env_var_override(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text("TIME_FORMAT=12h\n")
+        monkeypatch.setenv("TIME_FORMAT", "24h")
+        settings = load_settings(str(env_file))
+        assert settings.time_format == "24h"
+
+    def test_time_format_defaults_to_24h(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("")
+        os.environ.pop("TIME_FORMAT", None)
+        settings = load_settings(str(env_file))
+        assert settings.time_format == "24h"
 
     def test_xdg_config_home_respected(self, tmp_path, monkeypatch):
         xdg_config = tmp_path / "xdg_config"

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -34,6 +34,9 @@ class TestFormatDate:
     def test_formats_date_string(self):
         assert _format_date("2025-01-15") == "Jan 15, 2025"
 
+    def test_formats_single_digit_day(self):
+        assert _format_date("2025-03-04") == "Mar 4, 2025"
+
     def test_formats_end_of_month(self):
         assert _format_date("2025-02-28") == "Feb 28, 2025"
 
@@ -143,7 +146,7 @@ class TestRenderInvoiceHtml:
             settings=settings,
         )
         # Formatted dates should appear, not raw YYYY-MM-DD
-        assert "Jan 01, 2025" in html
+        assert "Jan 1, 2025" in html
         assert "Jan 31, 2025" in html
         assert "Jan 15, 2025" in html
         # Raw YYYY-MM-DD format should not appear for these dates

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -7,7 +7,7 @@ import pytest
 
 from timecard.config import Settings
 from timecard.db import add_entry, get_connection, get_entries
-from timecard.invoice import _get_period_dates, _render_invoice_html, generate_invoice
+from timecard.invoice import _format_date, _get_period_dates, _render_invoice_html, generate_invoice
 from timecard.models import Entry
 
 
@@ -28,6 +28,17 @@ def settings(tmp_path):
         invoice_output_dir=str(tmp_path / "invoices"),
         payment_instructions="Pay within 30 days.",
     )
+
+
+class TestFormatDate:
+    def test_formats_date_string(self):
+        assert _format_date("2025-01-15") == "Jan 15, 2025"
+
+    def test_formats_end_of_month(self):
+        assert _format_date("2025-02-28") == "Feb 28, 2025"
+
+    def test_formats_leap_day(self):
+        assert _format_date("2024-02-29") == "Feb 29, 2024"
 
 
 class TestGetPeriodDates:
@@ -110,6 +121,35 @@ class TestRenderInvoiceHtml:
             settings=settings,
         )
         assert "INV-0001" in html
+
+    def test_dates_are_human_readable(self, settings):
+        entries = [
+            Entry(
+                id=1,
+                started_at="2025-01-15T09:00:00",
+                ended_at="2025-01-15T12:00:00",
+                duration_minutes=180,
+                note="Work",
+            )
+        ]
+        html = _render_invoice_html(
+            entries=entries,
+            invoice_number="INV-0001",
+            period_start="2025-01-01",
+            period_end="2025-01-31",
+            total_hours=3.0,
+            total_amount=450.0,
+            hourly_rate=150.0,
+            settings=settings,
+        )
+        # Formatted dates should appear, not raw YYYY-MM-DD
+        assert "Jan 01, 2025" in html
+        assert "Jan 31, 2025" in html
+        assert "Jan 15, 2025" in html
+        # Raw YYYY-MM-DD format should not appear for these dates
+        assert "2025-01-01" not in html
+        assert "2025-01-31" not in html
+        assert "2025-01-15" not in html
 
 
 class TestGenerateInvoice:

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -34,6 +34,12 @@ def _get_conn():
         raise typer.Exit(code=2)
 
 
+def _format_ts(iso_str: str) -> str:
+    """Format an ISO 8601 UTC timestamp in the system's local timezone."""
+    dt = datetime.fromisoformat(iso_str).astimezone()
+    return dt.strftime("%b %d, %Y %-I:%M %p %Z")
+
+
 def _output(data: dict, as_json: bool) -> None:
     """Print output as JSON or human-readable text.
 
@@ -62,7 +68,7 @@ def start(
         _output({"error": str(e)}, json_output)
         raise typer.Exit(code=1)
 
-    _output({"status": "started", "started_at": started_at}, json_output)
+    _output({"status": "started", "started_at": started_at if json_output else _format_ts(started_at)}, json_output)
 
 
 @app.command()
@@ -104,7 +110,7 @@ def pause(
         _output({"error": str(e)}, json_output)
         raise typer.Exit(code=1)
 
-    _output({"status": "paused", "paused_at": paused_at}, json_output)
+    _output({"status": "paused", "paused_at": paused_at if json_output else _format_ts(paused_at)}, json_output)
 
 
 @app.command()
@@ -121,7 +127,7 @@ def resume(
         _output({"error": str(e)}, json_output)
         raise typer.Exit(code=1)
 
-    _output({"status": "resumed", "resumed_at": resumed_at}, json_output)
+    _output({"status": "resumed", "resumed_at": resumed_at if json_output else _format_ts(resumed_at)}, json_output)
 
 
 @app.command()
@@ -133,6 +139,8 @@ def status(
 
     conn = _get_conn()
     result = get_timer_status(conn)
+    if not json_output and result.get("started_at"):
+        result = {**result, "started_at": _format_ts(result["started_at"])}
     _output(result, json_output)
 
 

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -37,8 +37,22 @@ def _get_conn():
 def _format_ts(iso_str: str, time_format: str = "24h") -> str:
     """Format an ISO 8601 UTC timestamp in the system's local timezone."""
     dt = datetime.fromisoformat(iso_str).astimezone()
-    fmt = "%b %d, %Y %-I:%M %p %Z" if time_format == "12h" else "%b %d, %Y %H:%M %Z"
-    return dt.strftime(fmt)
+    date_part = f"{dt.strftime('%b')} {dt.day}, {dt.year}"
+    if time_format == "12h":
+        hour_12 = int(dt.strftime("%I"))  # %I is always supported; int() drops leading zero
+        return f"{date_part} {hour_12}:{dt.strftime('%M %p %Z')}"
+    return f"{date_part} {dt.strftime('%H:%M %Z')}"
+
+
+def _get_conn_and_settings():
+    """Get a database connection and settings together (single config parse)."""
+    settings = load_settings()
+    try:
+        conn = get_connection(settings.get_db_path())
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=2)
+    return conn, settings
 
 
 def _output(data: dict, as_json: bool) -> None:
@@ -62,8 +76,7 @@ def start(
     """Start a timer session."""
     from timecard.timer import start_timer
 
-    conn = _get_conn()
-    settings = load_settings()
+    conn, settings = _get_conn_and_settings()
     try:
         started_at = start_timer(conn)
     except ValueError as e:
@@ -105,8 +118,7 @@ def pause(
     """Pause the current timer session."""
     from timecard.timer import pause_timer
 
-    conn = _get_conn()
-    settings = load_settings()
+    conn, settings = _get_conn_and_settings()
     try:
         paused_at = pause_timer(conn)
     except ValueError as e:
@@ -123,8 +135,7 @@ def resume(
     """Resume a paused timer session."""
     from timecard.timer import resume_timer
 
-    conn = _get_conn()
-    settings = load_settings()
+    conn, settings = _get_conn_and_settings()
     try:
         resumed_at = resume_timer(conn)
     except ValueError as e:
@@ -141,8 +152,7 @@ def status(
     """Show whether a timer is running and for how long."""
     from timecard.timer import get_timer_status
 
-    conn = _get_conn()
-    settings = load_settings()
+    conn, settings = _get_conn_and_settings()
     result = get_timer_status(conn)
     if not json_output and result.get("started_at"):
         result = {**result, "started_at": _format_ts(result["started_at"], settings.time_format)}

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -34,10 +34,11 @@ def _get_conn():
         raise typer.Exit(code=2)
 
 
-def _format_ts(iso_str: str) -> str:
+def _format_ts(iso_str: str, time_format: str = "24h") -> str:
     """Format an ISO 8601 UTC timestamp in the system's local timezone."""
     dt = datetime.fromisoformat(iso_str).astimezone()
-    return dt.strftime("%b %d, %Y %-I:%M %p %Z")
+    fmt = "%b %d, %Y %-I:%M %p %Z" if time_format == "12h" else "%b %d, %Y %H:%M %Z"
+    return dt.strftime(fmt)
 
 
 def _output(data: dict, as_json: bool) -> None:
@@ -62,13 +63,14 @@ def start(
     from timecard.timer import start_timer
 
     conn = _get_conn()
+    settings = load_settings()
     try:
         started_at = start_timer(conn)
     except ValueError as e:
         _output({"error": str(e)}, json_output)
         raise typer.Exit(code=1)
 
-    _output({"status": "started", "started_at": started_at if json_output else _format_ts(started_at)}, json_output)
+    _output({"status": "started", "started_at": started_at if json_output else _format_ts(started_at, settings.time_format)}, json_output)
 
 
 @app.command()
@@ -104,13 +106,14 @@ def pause(
     from timecard.timer import pause_timer
 
     conn = _get_conn()
+    settings = load_settings()
     try:
         paused_at = pause_timer(conn)
     except ValueError as e:
         _output({"error": str(e)}, json_output)
         raise typer.Exit(code=1)
 
-    _output({"status": "paused", "paused_at": paused_at if json_output else _format_ts(paused_at)}, json_output)
+    _output({"status": "paused", "paused_at": paused_at if json_output else _format_ts(paused_at, settings.time_format)}, json_output)
 
 
 @app.command()
@@ -121,13 +124,14 @@ def resume(
     from timecard.timer import resume_timer
 
     conn = _get_conn()
+    settings = load_settings()
     try:
         resumed_at = resume_timer(conn)
     except ValueError as e:
         _output({"error": str(e)}, json_output)
         raise typer.Exit(code=1)
 
-    _output({"status": "resumed", "resumed_at": resumed_at if json_output else _format_ts(resumed_at)}, json_output)
+    _output({"status": "resumed", "resumed_at": resumed_at if json_output else _format_ts(resumed_at, settings.time_format)}, json_output)
 
 
 @app.command()
@@ -138,9 +142,10 @@ def status(
     from timecard.timer import get_timer_status
 
     conn = _get_conn()
+    settings = load_settings()
     result = get_timer_status(conn)
     if not json_output and result.get("started_at"):
-        result = {**result, "started_at": _format_ts(result["started_at"])}
+        result = {**result, "started_at": _format_ts(result["started_at"], settings.time_format)}
     _output(result, json_output)
 
 
@@ -376,6 +381,16 @@ def setup() -> None:
             break
         typer.echo("Invoice number offset must be 0 or greater.")
 
+
+    while True:
+        time_format = typer.prompt(
+            "Time format (12h or 24h)",
+            default=file_vals.get("TIME_FORMAT", "24h"),
+        ).strip().lower()
+        if time_format in ("12h", "24h"):
+            break
+        typer.echo("Time format must be '12h' or '24h'.")
+
     lines = [
         f"CONTRACTOR_NAME={_quote(contractor_name)}",
         f"CONTRACTOR_ADDRESS={_quote(contractor_address)}",
@@ -386,6 +401,7 @@ def setup() -> None:
         f"INVOICE_OUTPUT_DIR={_quote(invoice_output_dir)}",
         f"PAYMENT_INSTRUCTIONS={_quote(payment_instructions)}",
         f"INVOICE_NUMBER_START={invoice_number_start}",
+        f"TIME_FORMAT={time_format}",
     ]
 
     config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/timecard/config.py
+++ b/timecard/config.py
@@ -47,6 +47,7 @@ class Settings:
     payment_instructions: str = "Please remit payment within 30 days."
     db_path: str = str(DEFAULT_DB_PATH)
     invoice_number_start: int = 0
+    time_format: str = "24h"
 
     def get_db_path(self) -> Path:
         """Return the resolved database path, creating parent directories if needed.
@@ -122,4 +123,5 @@ def load_settings(env_path: Optional[str] = None) -> Settings:
         ),
         db_path=_get("TIMECARD_DB_PATH", str(DEFAULT_DB_PATH)),
         invoice_number_start=int(_get("INVOICE_NUMBER_START", "0")),
+        time_format=_get("TIME_FORMAT", "24h"),
     )

--- a/timecard/config.py
+++ b/timecard/config.py
@@ -35,6 +35,9 @@ class Settings:
                               Set via INVOICE_NUMBER_START for users migrating
                               from a prior invoicing system (e.g. 100 → first
                               invoice is INV-0101).
+        time_format: Clock format for human-readable CLI output. '12h' shows
+                     hours as 1–12 with AM/PM; '24h' (default) shows hours as
+                     0–23. Set via TIME_FORMAT in .env.
     """
 
     hourly_rate: float = 150.0

--- a/timecard/invoice.py
+++ b/timecard/invoice.py
@@ -17,6 +17,11 @@ from timecard.db import (
 from timecard.models import Entry, Invoice
 
 
+def _format_date(date_str: str) -> str:
+    """Format a YYYY-MM-DD date string as 'Mar 24, 2026'."""
+    return datetime.strptime(date_str, "%Y-%m-%d").strftime("%b %d, %Y")
+
+
 def _get_period_dates(period: str) -> tuple[str, str]:
     """Calculate start and end dates for a calendar-aligned billing period.
 
@@ -208,14 +213,14 @@ def _render_invoice_html(
     for entry in entries:
         date_str = entry.started_at[:10] if entry.started_at else "N/A"
         line_items.append(
-            {"date": date_str, "note": entry.note, "hours": entry.hours()}
+            {"date": _format_date(date_str) if date_str != "N/A" else date_str, "note": entry.note, "hours": entry.hours()}
         )
 
     return template.render(
         invoice_number=invoice_number,
-        created_date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        period_start=period_start,
-        period_end=period_end,
+        created_date=datetime.now(timezone.utc).strftime("%b %d, %Y"),
+        period_start=_format_date(period_start),
+        period_end=_format_date(period_end),
         contractor_name=settings.contractor_name,
         contractor_address=settings.contractor_address,
         contractor_email=settings.contractor_email,

--- a/timecard/invoice.py
+++ b/timecard/invoice.py
@@ -18,8 +18,9 @@ from timecard.models import Entry, Invoice
 
 
 def _format_date(date_str: str) -> str:
-    """Format a YYYY-MM-DD date string as 'Mar 24, 2026'."""
-    return datetime.strptime(date_str, "%Y-%m-%d").strftime("%b %d, %Y")
+    """Format a YYYY-MM-DD date string as 'Mar 4, 2026' (no leading zero on day)."""
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return f"{dt.strftime('%b')} {dt.day}, {dt.year}"
 
 
 def _get_period_dates(period: str) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- Timer commands (`start`, `pause`, `resume`, `status`) now display timestamps in the user's local timezone as `Mar 24, 2026 10:30 AM PDT` instead of raw ISO 8601 UTC strings
- `--json` output is unchanged — raw ISO timestamps preserved for machine readability
- Invoice dates (created date, period range, line items) now render as `Mar 24, 2026` instead of `YYYY-MM-DD`

## Test plan
- [ ] `timecard start` shows formatted local time with timezone abbreviation
- [ ] `timecard start --json` still shows raw ISO timestamp
- [ ] `timecard status` shows formatted `started_at`
- [ ] `timecard pause` / `timecard resume` show formatted timestamps
- [ ] Generated invoice PDF shows dates like "Mar 24, 2026" throughout
- [ ] `uv run pytest -v` — 139/139 passing