### PR TITLE
feat: invoice lifecycle — list, paid status, and filtering (v1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Config file now defaults to `~/.config/timecard/.env` (XDG Base Directory spec)
 - Database now defaults to `~/.local/share/timecard/timecard.db` (XDG Base Directory spec)
 - `INVOICE_NUMBER_START` config variable — offsets auto-incremented invoice numbers for users migrating from a prior invoicing system (e.g. `INVOICE_NUMBER_START=100` → first invoice is `INV-0101`)
-- `--number` flag on `timecard invoice` — overrides the auto-incremented invoice number for a single invocation; raises an error if the number is already in use
+- `--number` flag on `timecard invoice generate` — overrides the auto-incremented invoice number for a single invocation; raises an error if the number is already in use
+- `timecard invoice list` — shows all past invoices (ID, number, period, hours, amount, paid-at date) with optional `--paid`/`--unpaid` filtering and `--json` support
+- `timecard invoice paid <number|id>` — marks an invoice as paid, recording a UTC timestamp; accepts the invoice's string number (`INV-0001`) or integer ID (`1`); optional `--date YYYY-MM-DD` to record a specific payment date instead of today
+- `timecard invoice unpaid <number|id>` — clears the paid status of an invoice
+- `paid_at` column added to the `invoices` database table (schema migration v2)
+- MCP tools: `list_invoices`, `mark_paid` (with optional `paid_at`), `mark_unpaid`
 
 ### Changed
 - Install scripts now install from the GitHub git URL instead of requiring a local clone
+- `timecard invoice` is now a command group; invoice generation moved to `timecard invoice generate`
 
 ## [1.1.0] - 2026-03-04
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Installs `uv` and prompts you to install the [GTK3 runtime](https://github.com/n
 ### Developer install (from source)
 
 ```bash
-uv tool install .
+uv cache clean && uv tool install --reinstall .
 ```
+
+Re-run the same command to pick up changes. The cache clear ensures uv doesn't serve a stale build.
 
 ## Updating
 
@@ -150,23 +152,52 @@ entry_id: 2
 ### Generate an invoice
 
 ```bash
-$ timecard invoice --note "January backend work"
+$ timecard invoice generate --note "January backend work"
 status: generated
 invoice_number: INV-0001
 total_hours: 3.01
 total_amount: 451.5
 pdf_path: /home/user/invoices/INV-0001.pdf
+paid_at: None
 
-$ timecard invoice --period month --output ./custom-invoice.pdf
+$ timecard invoice generate --period month --output ./custom-invoice.pdf
 
 # Override the invoice number for a single invocation
-$ timecard invoice --number 42
+$ timecard invoice generate --number 42
 invoice_number: INV-0042
 ```
 
 When no `--period` is specified, all uninvoiced entries are included. Period options (`week`, `biweekly`, `month`) use calendar-aligned windows (e.g., last complete Mon–Sun week, last complete calendar month).
 
 To start invoice numbering at a specific offset (e.g. when migrating from a prior system), set `INVOICE_NUMBER_START` in your `.env`. With `INVOICE_NUMBER_START=100`, the first invoice will be `INV-0101`.
+
+### List invoices
+
+```bash
+$ timecard invoice list
+ID    NUMBER      PERIOD                          HOURS   AMOUNT      PAID AT
+----------------------------------------------------------------------------
+1     INV-0001    2025-01-01 – 2025-01-15        3.01    $451.50     —
+2     INV-0002    2025-01-16 – 2025-01-31        8.00    $1200.00    Jan 31, 2025
+
+# Filter to outstanding or settled invoices
+$ timecard invoice list --unpaid
+$ timecard invoice list --paid --json
+```
+
+### Mark an invoice as paid
+
+```bash
+# By invoice number or ID — both work
+$ timecard invoice paid INV-0001
+$ timecard invoice paid 1
+
+# Record a specific payment date
+$ timecard invoice paid INV-0001 --date 2025-02-01
+
+# Undo a payment (e.g. if marked paid by mistake)
+$ timecard invoice unpaid INV-0001
+```
 
 ### JSON output
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,9 +21,10 @@
 - [x] `--number` flag on `timecard invoice` to override the auto-incremented number for a single invocation
 
 ## v1.3 — Invoice Lifecycle
-- [ ] `timecard invoice list` command to view past invoices (number, date, total hours, amount, PDF path)
-- [ ] `timecard invoice paid <invoice-number>` command to mark an invoice as paid, recording the payment date
-- [ ] `--paid` / `--unpaid` filter flags on `timecard invoice list` to view outstanding or settled invoices
+- [x] `timecard invoice list` command to view past invoices (number, date, total hours, amount, PDF path)
+- [x] `timecard invoice paid <invoice-number>` command to mark an invoice as paid, recording the payment date
+- [x] `timecard invoice unpaid <invoice-number>` command to reverse a paid status
+- [x] `--paid` / `--unpaid` filter flags on `timecard invoice list` to view outstanding or settled invoices
 - [ ] Python version check in `install.sh` / `install.ps1` — fail with a clear message if the system Python is below the minimum required version, and optionally guide users to install a compatible version
 
 ## v1.4 — Multi-Machine Support

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -36,7 +36,11 @@ This starts a stdio-based MCP server. Configure it in your agent client (e.g., C
 | `get_log` | `period?: str` | Return entries as a list (optional period filter) |
 | `edit_entry` | `id: int`, `hours?: float`, `note?: str` | Update an existing entry |
 | `delete_entry_tool` | `id: int` | Delete an entry |
-| `generate_invoice` | `period?: str`, `note?: str` | Generate a PDF invoice |
+| `export_csv` | `period?: str` | Export entries as a CSV string |
+| `generate_invoice` | `period?: str`, `note?: str`, `number?: int` | Generate a PDF invoice |
+| `list_invoices` | `paid?: bool` | List invoices; `True` = paid only, `False` = unpaid only, omit for all |
+| `mark_paid` | `invoice_number: str`, `paid_at?: str` | Mark an invoice as paid (ISO 8601 timestamp; defaults to now) |
+| `mark_unpaid` | `invoice_number: str` | Clear the paid status of an invoice |
 
 ## Example Agent Interaction
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,6 +301,47 @@ class TestInvoice:
         data = json.loads(result.stdout)
         assert "error" in data
 
+    @patch("timecard.invoice._write_pdf")
+    def test_invoice_paid_custom_date(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        result = runner.invoke(app, ["invoice", "paid", "INV-0001", "--date", "2025-03-01", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["paid_at"].startswith("2025-03-01")
+
+    def test_invoice_paid_invalid_date(self, tmp_db):
+        result = runner.invoke(app, ["invoice", "paid", "INV-0001", "--date", "not-a-date", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.stdout)
+        assert "error" in data
+
+    @patch("timecard.invoice._write_pdf")
+    def test_invoice_unpaid_success(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        runner.invoke(app, ["invoice", "paid", "INV-0001"])
+        result = runner.invoke(app, ["invoice", "unpaid", "INV-0001", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "unpaid"
+        assert data["invoice_number"] == "INV-0001"
+
+    def test_invoice_unpaid_not_found(self, tmp_db):
+        result = runner.invoke(app, ["invoice", "unpaid", "INV-9999", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.stdout)
+        assert "error" in data
+
+    @patch("timecard.invoice._write_pdf")
+    def test_invoice_generate_includes_paid_at(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        result = runner.invoke(app, ["invoice", "generate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "paid_at" in data
+        assert data["paid_at"] is None
+
 
 class TestSetup:
     def test_setup_creates_config(self, tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,6 +334,25 @@ class TestInvoice:
         assert "error" in data
 
     @patch("timecard.invoice._write_pdf")
+    def test_invoice_paid_by_id(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        result = runner.invoke(app, ["invoice", "paid", "1", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["invoice_number"] == "INV-0001"
+
+    @patch("timecard.invoice._write_pdf")
+    def test_invoice_unpaid_by_id(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        runner.invoke(app, ["invoice", "paid", "1"])
+        result = runner.invoke(app, ["invoice", "unpaid", "1", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["invoice_number"] == "INV-0001"
+
+    @patch("timecard.invoice._write_pdf")
     def test_invoice_generate_includes_paid_at(self, mock_pdf, tmp_db):
         runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
         result = runner.invoke(app, ["invoice", "generate", "--json"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,7 +227,7 @@ class TestInvoice:
     @patch("timecard.invoice._write_pdf")
     def test_generate_invoice(self, mock_pdf, tmp_db):
         runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
-        result = runner.invoke(app, ["invoice", "--json"])
+        result = runner.invoke(app, ["invoice", "generate", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert data["status"] == "generated"
@@ -236,16 +236,70 @@ class TestInvoice:
 
     @patch("timecard.invoice._write_pdf")
     def test_invoice_no_entries_errors(self, mock_pdf, tmp_db):
-        result = runner.invoke(app, ["invoice", "--json"])
+        result = runner.invoke(app, ["invoice", "generate", "--json"])
         assert result.exit_code == 1
 
     @patch("timecard.invoice._write_pdf")
     def test_invoice_number_override(self, mock_pdf, tmp_db):
         runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "2", "--note", "Work"])
-        result = runner.invoke(app, ["invoice", "--number", "42", "--json"])
+        result = runner.invoke(app, ["invoice", "generate", "--number", "42", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert data["invoice_number"] == "INV-0042"
+
+    def test_invoice_list_empty(self, tmp_db):
+        result = runner.invoke(app, ["invoice", "list"])
+        assert result.exit_code == 0
+        assert "No invoices found." in result.stdout
+
+    @patch("timecard.invoice._write_pdf")
+    def test_invoice_list_all(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        result = runner.invoke(app, ["invoice", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 1
+        assert data[0]["invoice_number"] == "INV-0001"
+        assert data[0]["total_hours"] == 3.0
+        assert data[0]["paid_at"] is None
+
+    @patch("timecard.invoice._write_pdf")
+    def test_invoice_list_paid_filter(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        runner.invoke(app, ["add", "--date", "2025-01-16", "--hours", "2", "--note", "More work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        runner.invoke(app, ["invoice", "paid", "INV-0001"])
+
+        paid_result = runner.invoke(app, ["invoice", "list", "--paid", "--json"])
+        assert paid_result.exit_code == 0
+        paid_data = json.loads(paid_result.stdout)
+        assert len(paid_data) == 1
+        assert paid_data[0]["invoice_number"] == "INV-0001"
+
+        unpaid_result = runner.invoke(app, ["invoice", "list", "--unpaid", "--json"])
+        assert unpaid_result.exit_code == 0
+        unpaid_data = json.loads(unpaid_result.stdout)
+        assert len(unpaid_data) == 1
+        assert unpaid_data[0]["invoice_number"] == "INV-0002"
+
+    @patch("timecard.invoice._write_pdf")
+    def test_invoice_paid_success(self, mock_pdf, tmp_db):
+        runner.invoke(app, ["add", "--date", "2025-01-15", "--hours", "3", "--note", "Work"])
+        runner.invoke(app, ["invoice", "generate", "--json"])
+        result = runner.invoke(app, ["invoice", "paid", "INV-0001", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "paid"
+        assert data["invoice_number"] == "INV-0001"
+        assert data["paid_at"] is not None
+
+    def test_invoice_paid_not_found(self, tmp_db):
+        result = runner.invoke(app, ["invoice", "paid", "INV-9999", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.stdout)
+        assert "error" in data
 
 
 class TestSetup:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,6 +260,7 @@ class TestInvoice:
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert len(data) == 1
+        assert data[0]["id"] == 1
         assert data[0]["invoice_number"] == "INV-0001"
         assert data[0]["total_hours"] == 3.0
         assert data[0]["paid_at"] is None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,8 +10,10 @@ from timecard.db import (
     get_connection,
     get_entries,
     get_entry,
+    get_invoices,
     get_next_invoice_number,
     mark_entries_invoiced,
+    mark_invoice_paid,
     start_session,
     stop_session,
     update_entry,
@@ -147,6 +149,71 @@ class TestInvoice:
             ),
         )
         assert get_next_invoice_number(conn) == "INV-0002"
+
+
+def _make_invoice(n: int) -> Invoice:
+    return Invoice(
+        invoice_number=f"INV-{n:04d}",
+        period_start="2025-01-01",
+        period_end="2025-01-15",
+        total_hours=1.0,
+        total_amount=150.0,
+        created_at=f"2025-01-{n:02d}T00:00:00",
+    )
+
+
+class TestInvoiceLifecycle:
+    def test_paid_at_column_exists(self, conn):
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(invoices)").fetchall()}
+        assert "paid_at" in cols
+
+    def test_get_invoices_empty(self, conn):
+        assert get_invoices(conn) == []
+
+    def test_get_invoices_all(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        add_invoice(conn, _make_invoice(2))
+        assert len(get_invoices(conn)) == 2
+
+    def test_get_invoices_paid_filter(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        add_invoice(conn, _make_invoice(2))
+        mark_invoice_paid(conn, "INV-0001")
+        paid = get_invoices(conn, paid=True)
+        assert len(paid) == 1
+        assert paid[0].invoice_number == "INV-0001"
+
+    def test_get_invoices_unpaid_filter(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        add_invoice(conn, _make_invoice(2))
+        mark_invoice_paid(conn, "INV-0001")
+        unpaid = get_invoices(conn, paid=False)
+        assert len(unpaid) == 1
+        assert unpaid[0].invoice_number == "INV-0002"
+
+    def test_mark_invoice_paid_success(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        result = mark_invoice_paid(conn, "INV-0001")
+        assert result is not None
+        assert result.invoice_number == "INV-0001"
+        assert result.paid_at is not None
+
+    def test_mark_invoice_paid_not_found(self, conn):
+        assert mark_invoice_paid(conn, "INV-9999") is None
+
+    def test_mark_invoice_paid_idempotent(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        first = mark_invoice_paid(conn, "INV-0001")
+        second = mark_invoice_paid(conn, "INV-0001")
+        assert second is not None
+        assert second.paid_at is not None
+
+    def test_paid_at_is_iso8601(self, conn):
+        from datetime import datetime
+
+        add_invoice(conn, _make_invoice(1))
+        result = mark_invoice_paid(conn, "INV-0001")
+        datetime.fromisoformat(result.paid_at)  # raises if invalid
 
 
 class TestActiveSession:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -14,6 +14,7 @@ from timecard.db import (
     get_next_invoice_number,
     mark_entries_invoiced,
     mark_invoice_paid,
+    mark_invoice_unpaid,
     start_session,
     stop_session,
     update_entry,
@@ -214,6 +215,25 @@ class TestInvoiceLifecycle:
         add_invoice(conn, _make_invoice(1))
         result = mark_invoice_paid(conn, "INV-0001")
         datetime.fromisoformat(result.paid_at)  # raises if invalid
+
+    def test_mark_invoice_paid_custom_date(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        result = mark_invoice_paid(conn, "INV-0001", paid_at="2025-03-01T00:00:00+00:00")
+        assert result.paid_at == "2025-03-01T00:00:00+00:00"
+
+    def test_mark_invoice_unpaid_success(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        mark_invoice_paid(conn, "INV-0001")
+        assert mark_invoice_unpaid(conn, "INV-0001") is True
+        invoices = get_invoices(conn, paid=False)
+        assert len(invoices) == 1
+
+    def test_mark_invoice_unpaid_not_found(self, conn):
+        assert mark_invoice_unpaid(conn, "INV-9999") is False
+
+    def test_mark_invoice_unpaid_already_unpaid(self, conn):
+        add_invoice(conn, _make_invoice(1))
+        assert mark_invoice_unpaid(conn, "INV-0001") is True
 
 
 class TestActiveSession:

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -297,6 +297,20 @@ invoice_app = typer.Typer(help="Invoice commands: generate, list, and mark as pa
 app.add_typer(invoice_app, name="invoice")
 
 
+def _resolve_invoice_number(conn, value: str) -> Optional[str]:
+    """Return the invoice_number for a given argument.
+
+    Accepts either a bare integer ID (e.g. "1") or a full invoice number
+    string (e.g. "INV-0042"). Returns None if the invoice is not found.
+    """
+    if value.isdigit():
+        row = conn.execute(
+            "SELECT invoice_number FROM invoices WHERE id = ?", (int(value),)
+        ).fetchone()
+        return row["invoice_number"] if row else None
+    return value
+
+
 @invoice_app.command("generate")
 def invoice_generate(
     period: Optional[str] = typer.Option(
@@ -388,7 +402,7 @@ def invoice_list(
 
 @invoice_app.command("paid")
 def invoice_paid(
-    invoice_number: str = typer.Argument(help="Invoice number (e.g. INV-0042)"),
+    invoice_ref: str = typer.Argument(help="Invoice number or ID (e.g. INV-0042 or 42)"),
     date: Optional[str] = typer.Option(
         None, "--date", help="Payment date (YYYY-MM-DD). Defaults to today."
     ),
@@ -408,6 +422,11 @@ def invoice_paid(
             raise typer.Exit(code=1)
 
     conn, settings = _get_conn_and_settings()
+    invoice_number = _resolve_invoice_number(conn, invoice_ref)
+    if invoice_number is None:
+        _output({"error": f"Invoice {invoice_ref!r} not found."}, json_output)
+        raise typer.Exit(code=1)
+
     result = mark_invoice_paid(conn, invoice_number, paid_at=paid_at)
     if result is None:
         _output({"error": f"Invoice {invoice_number} not found."}, json_output)
@@ -427,13 +446,18 @@ def invoice_paid(
 
 @invoice_app.command("unpaid")
 def invoice_unpaid(
-    invoice_number: str = typer.Argument(help="Invoice number (e.g. INV-0042)"),
+    invoice_ref: str = typer.Argument(help="Invoice number or ID (e.g. INV-0042 or 42)"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Mark an invoice as unpaid."""
     from timecard.db import mark_invoice_unpaid
 
-    conn = _get_conn()
+    conn, _ = _get_conn_and_settings()
+    invoice_number = _resolve_invoice_number(conn, invoice_ref)
+    if invoice_number is None:
+        _output({"error": f"Invoice {invoice_ref!r} not found."}, json_output)
+        raise typer.Exit(code=1)
+
     found = mark_invoice_unpaid(conn, invoice_number)
     if not found:
         _output({"error": f"Invoice {invoice_number} not found."}, json_output)

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -326,8 +326,7 @@ def invoice_generate(
     """Generate a PDF invoice for uninvoiced entries."""
     from timecard.invoice import generate_invoice
 
-    conn = _get_conn()
-    settings = load_settings()
+    conn, settings = _get_conn_and_settings()
 
     try:
         inv = generate_invoice(
@@ -360,7 +359,7 @@ def invoice_list(
     """List past invoices."""
     from timecard.db import get_invoices
 
-    conn, settings = _get_conn_and_settings()
+    conn = _get_conn()
     invoices = get_invoices(conn, paid=paid)
 
     if json_output:

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -392,9 +392,11 @@ def invoice_list(
     typer.echo("-" * 76)
     for inv in invoices:
         period_str = f"{inv.period_start} – {inv.period_end}"
-        paid_str = (
-            _format_ts(inv.paid_at, settings.time_format) if inv.paid_at else "—"
-        )
+        if inv.paid_at:
+            from timecard.invoice import _format_date
+            paid_str = _format_date(inv.paid_at[:10])
+        else:
+            paid_str = "—"
         amount_str = f"${inv.total_amount:.2f}"
         typer.echo(
             f"{inv.id:<6}{inv.invoice_number:<12}{period_str:<30}{inv.total_hours:<8.2f}{amount_str:<12}{paid_str}"

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -368,6 +368,7 @@ def invoice_list(
             json.dumps(
                 [
                     {
+                        "id": inv.id,
                         "invoice_number": inv.invoice_number,
                         "period_start": inv.period_start,
                         "period_end": inv.period_end,
@@ -387,8 +388,8 @@ def invoice_list(
         typer.echo("No invoices found.")
         return
 
-    typer.echo(f"{'NUMBER':<12}{'PERIOD':<30}{'HOURS':<8}{'AMOUNT':<12}{'PAID'}")
-    typer.echo("-" * 70)
+    typer.echo(f"{'ID':<6}{'NUMBER':<12}{'PERIOD':<30}{'HOURS':<8}{'AMOUNT':<12}{'PAID'}")
+    typer.echo("-" * 76)
     for inv in invoices:
         period_str = f"{inv.period_start} – {inv.period_end}"
         paid_str = (
@@ -396,7 +397,7 @@ def invoice_list(
         )
         amount_str = f"${inv.total_amount:.2f}"
         typer.echo(
-            f"{inv.invoice_number:<12}{period_str:<30}{inv.total_hours:<8.2f}{amount_str:<12}{paid_str}"
+            f"{inv.id:<6}{inv.invoice_number:<12}{period_str:<30}{inv.total_hours:<8.2f}{amount_str:<12}{paid_str}"
         )
 
 

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -388,12 +388,12 @@ def invoice_list(
         typer.echo("No invoices found.")
         return
 
-    typer.echo(f"{'ID':<6}{'NUMBER':<12}{'PERIOD':<30}{'HOURS':<8}{'AMOUNT':<12}{'PAID'}")
+    typer.echo(f"{'ID':<6}{'NUMBER':<12}{'PERIOD':<30}{'HOURS':<8}{'AMOUNT':<12}{'PAID AT'}")
     typer.echo("-" * 76)
     for inv in invoices:
         period_str = f"{inv.period_start} – {inv.period_end}"
         paid_str = (
-            _format_ts(inv.paid_at, settings.time_format) if inv.paid_at else "No"
+            _format_ts(inv.paid_at, settings.time_format) if inv.paid_at else "—"
         )
         amount_str = f"${inv.total_amount:.2f}"
         typer.echo(

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -293,8 +293,12 @@ def export(
         typer.echo(csv_text, nl=False)
 
 
-@app.command()
-def invoice(
+invoice_app = typer.Typer(help="Invoice commands: generate, list, and mark as paid.")
+app.add_typer(invoice_app, name="invoice")
+
+
+@invoice_app.command("generate")
+def invoice_generate(
     period: Optional[str] = typer.Option(
         None, help="Billing period: week, biweekly, or month"
     ),
@@ -326,6 +330,82 @@ def invoice(
             "total_hours": inv.total_hours,
             "total_amount": inv.total_amount,
             "pdf_path": inv.pdf_path,
+        },
+        json_output,
+    )
+
+
+@invoice_app.command("list")
+def invoice_list(
+    paid: Optional[bool] = typer.Option(
+        None, "--paid/--unpaid", help="Filter by payment status"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """List past invoices."""
+    from timecard.db import get_invoices
+
+    conn, settings = _get_conn_and_settings()
+    invoices = get_invoices(conn, paid=paid)
+
+    if json_output:
+        typer.echo(
+            json.dumps(
+                [
+                    {
+                        "invoice_number": inv.invoice_number,
+                        "period_start": inv.period_start,
+                        "period_end": inv.period_end,
+                        "total_hours": inv.total_hours,
+                        "total_amount": inv.total_amount,
+                        "pdf_path": inv.pdf_path,
+                        "paid_at": inv.paid_at,
+                    }
+                    for inv in invoices
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    if not invoices:
+        typer.echo("No invoices found.")
+        return
+
+    typer.echo(f"{'NUMBER':<12}{'PERIOD':<30}{'HOURS':<8}{'AMOUNT':<12}{'PAID'}")
+    typer.echo("-" * 70)
+    for inv in invoices:
+        period_str = f"{inv.period_start} – {inv.period_end}"
+        paid_str = (
+            _format_ts(inv.paid_at, settings.time_format) if inv.paid_at else "No"
+        )
+        amount_str = f"${inv.total_amount:.2f}"
+        typer.echo(
+            f"{inv.invoice_number:<12}{period_str:<30}{inv.total_hours:<8.2f}{amount_str:<12}{paid_str}"
+        )
+
+
+@invoice_app.command("paid")
+def invoice_paid(
+    invoice_number: str = typer.Argument(help="Invoice number (e.g. INV-0042)"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Mark an invoice as paid."""
+    from timecard.db import mark_invoice_paid
+
+    conn, settings = _get_conn_and_settings()
+    result = mark_invoice_paid(conn, invoice_number)
+    if result is None:
+        _output({"error": f"Invoice {invoice_number} not found."}, json_output)
+        raise typer.Exit(code=1)
+
+    _output(
+        {
+            "status": "paid",
+            "invoice_number": result.invoice_number,
+            "paid_at": result.paid_at
+            if json_output
+            else _format_ts(result.paid_at, settings.time_format),
         },
         json_output,
     )

--- a/timecard/cli.py
+++ b/timecard/cli.py
@@ -330,6 +330,7 @@ def invoice_generate(
             "total_hours": inv.total_hours,
             "total_amount": inv.total_amount,
             "pdf_path": inv.pdf_path,
+            "paid_at": inv.paid_at,
         },
         json_output,
     )
@@ -388,13 +389,26 @@ def invoice_list(
 @invoice_app.command("paid")
 def invoice_paid(
     invoice_number: str = typer.Argument(help="Invoice number (e.g. INV-0042)"),
+    date: Optional[str] = typer.Option(
+        None, "--date", help="Payment date (YYYY-MM-DD). Defaults to today."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Mark an invoice as paid."""
     from timecard.db import mark_invoice_paid
 
+    paid_at = None
+    if date is not None:
+        try:
+            paid_at = datetime.fromisoformat(date).replace(
+                tzinfo=timezone.utc
+            ).isoformat()
+        except ValueError:
+            _output({"error": f"Invalid date format: {date!r}. Use YYYY-MM-DD."}, json_output)
+            raise typer.Exit(code=1)
+
     conn, settings = _get_conn_and_settings()
-    result = mark_invoice_paid(conn, invoice_number)
+    result = mark_invoice_paid(conn, invoice_number, paid_at=paid_at)
     if result is None:
         _output({"error": f"Invoice {invoice_number} not found."}, json_output)
         raise typer.Exit(code=1)
@@ -409,6 +423,23 @@ def invoice_paid(
         },
         json_output,
     )
+
+
+@invoice_app.command("unpaid")
+def invoice_unpaid(
+    invoice_number: str = typer.Argument(help="Invoice number (e.g. INV-0042)"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Mark an invoice as unpaid."""
+    from timecard.db import mark_invoice_unpaid
+
+    conn = _get_conn()
+    found = mark_invoice_unpaid(conn, invoice_number)
+    if not found:
+        _output({"error": f"Invoice {invoice_number} not found."}, json_output)
+        raise typer.Exit(code=1)
+
+    _output({"status": "unpaid", "invoice_number": invoice_number}, json_output)
 
 
 def _quote(value: str) -> str:

--- a/timecard/db.py
+++ b/timecard/db.py
@@ -1,6 +1,7 @@
 """SQLite database layer for TimeCard — schema initialization and CRUD operations."""
 
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -86,6 +87,13 @@ def _migrate(conn: sqlite3.Connection) -> None:
         if "paused_duration_minutes" not in cols:
             conn.execute("ALTER TABLE active_session ADD COLUMN paused_duration_minutes REAL DEFAULT 0")
         conn.execute("UPDATE _schema_version SET version = 1 WHERE id = 1")
+        conn.commit()
+
+    if version < 2:
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(invoices)").fetchall()}
+        if "paid_at" not in cols:
+            conn.execute("ALTER TABLE invoices ADD COLUMN paid_at TEXT")
+        conn.execute("UPDATE _schema_version SET version = 2 WHERE id = 1")
         conn.commit()
 
 
@@ -300,6 +308,60 @@ def get_next_invoice_number(conn: sqlite3.Connection, start_offset: int = 0) -> 
     return f"INV-{next_num:04d}"
 
 
+def get_invoices(
+    conn: sqlite3.Connection,
+    paid: Optional[bool] = None,
+) -> list[Invoice]:
+    """Fetch invoices with optional paid/unpaid filter.
+
+    Args:
+        conn: An open SQLite connection.
+        paid: If True, return only paid invoices. If False, return only unpaid.
+              If None, return all invoices.
+
+    Returns:
+        List of Invoice objects ordered by created_at.
+    """
+    query = "SELECT * FROM invoices WHERE 1=1"
+    if paid is True:
+        query += " AND paid_at IS NOT NULL"
+    elif paid is False:
+        query += " AND paid_at IS NULL"
+    query += " ORDER BY created_at"
+    rows = conn.execute(query).fetchall()
+    return [_row_to_invoice(r) for r in rows]
+
+
+def mark_invoice_paid(
+    conn: sqlite3.Connection,
+    invoice_number: str,
+) -> Optional[Invoice]:
+    """Mark an invoice as paid, recording the current UTC timestamp.
+
+    Args:
+        conn: An open SQLite connection.
+        invoice_number: The invoice number string (e.g. "INV-0042").
+
+    Returns:
+        The updated Invoice if found, else None.
+    """
+    row = conn.execute(
+        "SELECT * FROM invoices WHERE invoice_number = ?", (invoice_number,)
+    ).fetchone()
+    if row is None:
+        return None
+    paid_at = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "UPDATE invoices SET paid_at = ? WHERE invoice_number = ?",
+        (paid_at, invoice_number),
+    )
+    conn.commit()
+    updated = conn.execute(
+        "SELECT * FROM invoices WHERE invoice_number = ?", (invoice_number,)
+    ).fetchone()
+    return _row_to_invoice(updated)
+
+
 # --- Active Session CRUD ---
 
 
@@ -427,6 +489,22 @@ def resume_session(conn: sqlite3.Connection, resumed_at: str) -> ActiveSession:
     session.paused_at = None
     session.paused_duration_minutes = new_paused
     return session
+
+
+def _row_to_invoice(row: sqlite3.Row) -> Invoice:
+    """Convert a sqlite3.Row to an Invoice dataclass."""
+    return Invoice(
+        id=row["id"],
+        invoice_number=row["invoice_number"],
+        period_start=row["period_start"],
+        period_end=row["period_end"],
+        total_hours=row["total_hours"],
+        total_amount=row["total_amount"],
+        created_at=row["created_at"],
+        pdf_path=row["pdf_path"],
+        note=row["note"],
+        paid_at=row["paid_at"],
+    )
 
 
 def _row_to_entry(row: sqlite3.Row) -> Entry:

--- a/timecard/db.py
+++ b/timecard/db.py
@@ -335,12 +335,15 @@ def get_invoices(
 def mark_invoice_paid(
     conn: sqlite3.Connection,
     invoice_number: str,
+    paid_at: Optional[str] = None,
 ) -> Optional[Invoice]:
-    """Mark an invoice as paid, recording the current UTC timestamp.
+    """Mark an invoice as paid.
 
     Args:
         conn: An open SQLite connection.
         invoice_number: The invoice number string (e.g. "INV-0042").
+        paid_at: ISO 8601 timestamp to record as the payment date.
+                 Defaults to the current UTC time if not provided.
 
     Returns:
         The updated Invoice if found, else None.
@@ -350,7 +353,8 @@ def mark_invoice_paid(
     ).fetchone()
     if row is None:
         return None
-    paid_at = datetime.now(timezone.utc).isoformat()
+    if paid_at is None:
+        paid_at = datetime.now(timezone.utc).isoformat()
     conn.execute(
         "UPDATE invoices SET paid_at = ? WHERE invoice_number = ?",
         (paid_at, invoice_number),
@@ -360,6 +364,27 @@ def mark_invoice_paid(
         "SELECT * FROM invoices WHERE invoice_number = ?", (invoice_number,)
     ).fetchone()
     return _row_to_invoice(updated)
+
+
+def mark_invoice_unpaid(
+    conn: sqlite3.Connection,
+    invoice_number: str,
+) -> bool:
+    """Clear the paid status of an invoice.
+
+    Args:
+        conn: An open SQLite connection.
+        invoice_number: The invoice number string (e.g. "INV-0042").
+
+    Returns:
+        True if the invoice was found and updated, False if not found.
+    """
+    cur = conn.execute(
+        "UPDATE invoices SET paid_at = NULL WHERE invoice_number = ?",
+        (invoice_number,),
+    )
+    conn.commit()
+    return cur.rowcount > 0
 
 
 # --- Active Session CRUD ---

--- a/timecard/mcp_server.py
+++ b/timecard/mcp_server.py
@@ -268,11 +268,12 @@ def list_invoices(paid: Optional[bool] = None) -> list[dict]:
 
 
 @mcp.tool()
-def mark_paid(invoice_number: str) -> dict:
+def mark_paid(invoice_number: str, paid_at: Optional[str] = None) -> dict:
     """Mark an invoice as paid.
 
     Args:
         invoice_number: The invoice number string (e.g. "INV-0042").
+        paid_at: ISO 8601 timestamp for the payment date. Defaults to now.
 
     Returns:
         Dict with status, invoice_number, and paid_at on success.
@@ -281,7 +282,7 @@ def mark_paid(invoice_number: str) -> dict:
     from timecard.db import mark_invoice_paid
 
     conn = _get_conn()
-    result = mark_invoice_paid(conn, invoice_number)
+    result = mark_invoice_paid(conn, invoice_number, paid_at=paid_at)
     if result is None:
         return {"error": f"Invoice {invoice_number} not found."}
     return {
@@ -289,6 +290,26 @@ def mark_paid(invoice_number: str) -> dict:
         "invoice_number": result.invoice_number,
         "paid_at": result.paid_at,
     }
+
+
+@mcp.tool()
+def mark_unpaid(invoice_number: str) -> dict:
+    """Clear the paid status of an invoice.
+
+    Args:
+        invoice_number: The invoice number string (e.g. "INV-0042").
+
+    Returns:
+        Dict with status and invoice_number on success.
+        Dict with 'error' key if invoice not found.
+    """
+    from timecard.db import mark_invoice_unpaid
+
+    conn = _get_conn()
+    found = mark_invoice_unpaid(conn, invoice_number)
+    if not found:
+        return {"error": f"Invoice {invoice_number} not found."}
+    return {"status": "unpaid", "invoice_number": invoice_number}
 
 
 def run_server() -> None:

--- a/timecard/mcp_server.py
+++ b/timecard/mcp_server.py
@@ -237,6 +237,60 @@ def generate_invoice(
     }
 
 
+@mcp.tool()
+def list_invoices(paid: Optional[bool] = None) -> list[dict]:
+    """List past invoices, optionally filtered by payment status.
+
+    Args:
+        paid: If True, return only paid invoices. If False, return only unpaid.
+              If None (default), return all invoices.
+
+    Returns:
+        List of invoice dicts with invoice_number, period_start, period_end,
+        total_hours, total_amount, pdf_path, and paid_at fields.
+    """
+    from timecard.db import get_invoices
+
+    conn = _get_conn()
+    invoices = get_invoices(conn, paid=paid)
+    return [
+        {
+            "invoice_number": inv.invoice_number,
+            "period_start": inv.period_start,
+            "period_end": inv.period_end,
+            "total_hours": inv.total_hours,
+            "total_amount": inv.total_amount,
+            "pdf_path": inv.pdf_path,
+            "paid_at": inv.paid_at,
+        }
+        for inv in invoices
+    ]
+
+
+@mcp.tool()
+def mark_paid(invoice_number: str) -> dict:
+    """Mark an invoice as paid.
+
+    Args:
+        invoice_number: The invoice number string (e.g. "INV-0042").
+
+    Returns:
+        Dict with status, invoice_number, and paid_at on success.
+        Dict with 'error' key if invoice not found.
+    """
+    from timecard.db import mark_invoice_paid
+
+    conn = _get_conn()
+    result = mark_invoice_paid(conn, invoice_number)
+    if result is None:
+        return {"error": f"Invoice {invoice_number} not found."}
+    return {
+        "status": "paid",
+        "invoice_number": result.invoice_number,
+        "paid_at": result.paid_at,
+    }
+
+
 def run_server() -> None:
     """Start the MCP server on stdio transport."""
     mcp.run(transport="stdio")

--- a/timecard/models.py
+++ b/timecard/models.py
@@ -48,6 +48,7 @@ class Invoice:
         created_at: ISO 8601 timestamp when the invoice was created.
         pdf_path: Local filesystem path to the generated PDF.
         note: Optional project/work description.
+        paid_at: ISO 8601 UTC timestamp when marked paid, or None if unpaid.
     """
 
     id: Optional[int] = None
@@ -59,6 +60,7 @@ class Invoice:
     created_at: Optional[str] = None
     pdf_path: Optional[str] = None
     note: Optional[str] = None
+    paid_at: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Converts \`timecard invoice\` from a flat command into a sub-app with three explicit subcommands: \`generate\`, \`list\`, and \`paid\`
- Adds \`timecard invoice list [--paid|--unpaid]\` to view past invoices in a table (ID, number, period, hours, amount, paid-at date) or JSON
- Adds \`timecard invoice paid <number|id> [--date YYYY-MM-DD]\` to mark an invoice as paid with an optional custom date (defaults to now)
- Adds \`timecard invoice unpaid <number|id>\` to reverse a paid status
- Both \`paid\` and \`unpaid\` accept the invoice's integer ID or its string number (e.g. \`1\` or \`INV-0001\`)
- Adds \`paid_at TEXT\` column to the \`invoices\` table via schema migration (version 2)
- Adds \`get_invoices()\`, \`mark_invoice_paid()\`, and \`mark_invoice_unpaid()\` to the DB layer
- Adds \`list_invoices\`, \`mark_paid\`, and \`mark_unpaid\` MCP tools

## Breaking change

\`timecard invoice --period week\` is replaced by \`timecard invoice generate --period week\`. The old flat invocation no longer works.

## Test plan

- [ ] \`uv run pytest -v\` — all tests pass
- [ ] \`timecard invoice generate --json\` generates an invoice
- [ ] \`timecard invoice list\` shows "No invoices found." when empty
- [ ] \`timecard invoice list --json\` returns a JSON array with \`id\`, \`invoice_number\`, and \`paid_at\`
- [ ] \`timecard invoice paid INV-0001\` and \`timecard invoice paid 1\` both work
- [ ] \`timecard invoice paid INV-0001 --date 2026-03-01\` records a custom payment date
- [ ] \`timecard invoice list --paid\` shows only paid invoices; \`--unpaid\` shows only unpaid
- [ ] \`timecard invoice unpaid INV-0001\` clears paid status
- [ ] \`timecard invoice paid INV-9999\` exits with code 1 and an error message